### PR TITLE
feat(sdk/python):Implement Driver Manager class 

### DIFF
--- a/sdk/python/conveyor/runtime/manager.py
+++ b/sdk/python/conveyor/runtime/manager.py
@@ -26,7 +26,7 @@ class DriverManager:
         if not self.driver:
             raise DriverRuntimeException("Invalid driver instance provided.")
 
-        if not self.events or not isinstance(self.events, List):
+        if not self.events:
             raise DriverRuntimeException("Events must be a non-empty list.")
 
         for event in self.events:
@@ -79,8 +79,7 @@ class DriverManager:
 
             if not event:  
                 logging.warning("Message missing event field")
-                await msg.term()
-                raise DriverRuntimeException("Message missing event field for driver %s." % self.driver.name)
+                raise Exception("Message missing event field for driver %s." % self.driver.name)
 
             logging.debug("Received message for event: %s", event)
 


### PR DESCRIPTION
**Issue #19 — Add `DriverManager`**

### What this adds

A `DriverManager` class that listens to NATS JetStream, filters events, and forwards them to the driver’s `reconcile()` method.

### Main points

* Processes JSON messages pushed from JetStream
* Filters events the driver is interested in (supports `*` wildcard)
* `ACK` on success, `NAK` on recoverable driver errors, `TERM` on malformed messages
* Graceful shutdown: `unsubscribe`, `drain`, then close the Loki client

### How it works

1. Creates a durable consumer with explicit-ack and `max_ack_pending = 1`.
2. For each message, skips irrelevant events, builds a `DriverLogger`, and calls `reconcile()`.
3. Handles errors and acknowledgments as described above.

### Usage

```python
manager = DriverManager(driver, events, nats_connection, loki_client)
await manager.run()

# later
await manager.shutdown()
```
