### PR TITLE
fix: reverted back to the initial workflows that uses tags instead of…

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,41 +1,52 @@
 name: Publish Conveyor Python Client Package to PyPI
 
+
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'python-v*'
+
 
 jobs:
   build-and-publish:
-    if: startsWith(github.event.release.tag_name, 'python-v')
-    name: Build and Publish Python SDK to PyPI
+    name: Build and Publish Conveyor Python Client SDK
     runs-on: ubuntu-latest
+
 
     defaults:
       run:
         working-directory: sdk/python
 
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Upgrade pip and install build tools
+
+      - name: Upgrade pip and install tools
         run: |
           python -m pip install --upgrade pip
           pip install build twine
 
+
       - name: Build the package
         run: python -m build
 
-      - name: Twine check
+
+      - name: Twine Dry Run 
         run: twine check dist/*
 
+
       - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/python-v') 
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
+


### PR DESCRIPTION
… releases

# Pull Request

## Description

Reverting back to the workflow that uses tags instead of  a release event in the workflow for publishing the python client

## Related Issues / Milestones
Fixes #28 
<!-- 
Link the issues this PR addresses. 
Use the "Fixes" keyword to auto-close issues after merge. 
Example: Fixes #12, Closes #34 
-->

---

## Type of Change

<!-- Select one by marking [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Security fix
- [ ] CI/CD or deployment

---

## How Has This Been Tested?

<!-- 
Describe the tests you ran to verify your changes.
Include instructions for reproducing the tests.
-->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

---

## Screenshots / Logs (If Applicable)

<!-- 
Attach relevant screenshots, terminal output, or logs
-->

---

## Checklist

- [x] My code follows the project coding guidelines
- [x] I have added/updated tests to cover my changes
- [x] I have updated the relevant documentation
- [x] I have assigned the correct labels and linked issues/milestones
- [x] This PR is ready for review

---

## Additional Notes

<!-- 
Add any extra information reviewers should know, or note any follow-up work.
-->
