### PR TITLE
Bug: Conveyor occasionally panics due to signal processing confliction with embedded NATS server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,48 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# Node.js
+node_modules/
+
+# env file
 .env
-output
-build/
-athens-data
+*/.env
+
+# Virtual Environments
 .venv
+*/.venv
+
+# Exclude locally built artifacts
+dist/
+build/
+output/
+
+# JetBrains related files
+.idea/
+.idea/*
+*/.idea
+
+# EtcD
 default.etcd
-node_modules
+*/default.etcd
+

--- a/internal/utils/nats.go
+++ b/internal/utils/nats.go
@@ -33,6 +33,7 @@ func NewNatsConn() *NatsContext {
 		JetStream: true,
 		StoreDir:  dataDir,
 		NoLog:     true,
+		NoSigs:    true,
 	}
 
 	log.Println("Starting embedded NATS server with JetStream...")


### PR DESCRIPTION
# Pull Request

## Description

To ensure that a nil channel is not closed twice, the NoSigs option was enabled on the embedded NATS server being used by conveyor. This is a small change made to the server.Config structure that gets passed to server.NewServer. 

Additionally, the .gitignore file was updated with the standard one provided by GitHub. Any previous entries that existed within this file have been merged to the new .gitignore file. 
---

## Related Issues / Milestones

Fixes: #103, Closes #103 

---

## Type of Change

- [ X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Security fix
- [ ] CI/CD or deployment

---

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [X ] Manual testing

---

## Screenshots / Logs (If Applicable)

See #103 

---

## Checklist

- [ X] My code follows the project coding guidelines
- [ N/A] I have added/updated tests to cover my changes
- [ N/A] I have updated the relevant documentation
- [ X] I have assigned the correct labels and linked issues/milestones
- [ X] This PR is ready for review

---

## Additional Notes

N/A
