### PR TITLE
ci(github): enable CI on branches & allow fork runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,13 @@
 name: Go Test
 
 on:
+  push:
+    branches:
+      - "**" # run on pushes to any branch in this repository
   pull_request:
     branches:
-      - "**" # Run on PRs to any branch
+      - "**" # still run on PRs
+  workflow_dispatch: {} # allow manual runs from the Actions UI
 
 jobs:
   test:
@@ -26,8 +30,3 @@ jobs:
       # Run tests
       - name: Run tests
         run: make test
-
-      - uses: qltysh/qlty-action/coverage@v1
-        with:
-          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
-          files: cover.out


### PR DESCRIPTION
This PR enables CI to run on branches and allows contributors to run the
workflow in their forks by:

- Adding `push` and `workflow_dispatch` triggers (keeps `pull_request`).
- Removing the coverage upload step that required `secrets.QLTY_COVERAGE_TOKEN`.

Why: Workflow runs from forks (and PRs from forks) cannot access repo
secrets, causing failures. Removing the secret-dependent step makes it
possible for contributors to test the CI (run tests) in their forks or
open PRs without failing.