### PR TITLE
chore: pre release 0.6.5

### DIFF
--- a/cmd/api/app.go
+++ b/cmd/api/app.go
@@ -3,7 +3,7 @@ Copyright © 2024 - Present Conveyor CI Contributors
 */
 
 // @title Conveyor CI API
-// @version 0.5.0
+// @version 0.6.5
 // @description Conveyor is a lightweight, distributed CI/CD engine built for platform developers who demand simplicity without compromise.
 
 // @contact.name Conveyor Support

--- a/docs/blog/2026-04-05-march-update.md
+++ b/docs/blog/2026-04-05-march-update.md
@@ -1,0 +1,19 @@
+---
+slug: march-2026-update
+title: Conveyor CI – March 2026 Progress Update
+authors: jim-junior
+tags: [conveyor-ci, update]
+---
+
+Here’s a quick summary of what’s been accomplished and what’s coming next.
+
+<!-- truncate -->
+
+## What’s New
+
+- Implemented Initial Rust Driver Runtime
+- Applied to the CNCF Sandbox
+
+## Next Steps
+
+- Design and implementation of **Variables**, these are dynamic variables that are applied in resources and pipelines and can be used to customize worklow behaviour.

--- a/docs/docs/contributing/roadmap.md
+++ b/docs/docs/contributing/roadmap.md
@@ -12,11 +12,12 @@ The Conveyor CI project is also managed via using [Github Projects](https://gith
 
 For the next upcoming period, Conveyor CI development is to follow a set of objectives. These objectives set the roadmap of 2026. And Development is to follow phases.
 
-| Phase   | Objective                                                                                                               |
-| ------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Phase 1 | <ul><li>Develop a Standard SDK implementation in Go</li><li>Enable Streaming Pipeline Logs</li></ul>                    |
-| Phase 2 | <ul><li>Parallel and Concurrent Workflow Execution</li><li>Development of SDKs for other programming language</li></ul> |
-| Phase 3 | <ul><li>CI/CD Directed acyclic graph(DAG)</li></ul>                                                                     |
-| Phase 4 | <ul><li>Secrets and Pipeline Variables</li></ul>                                                                        |
-| Phase 5 | <ul><li>Authorization and RBAC</li></ul>                                                                                |
-| Phase 6 | <ul><li>System Observability and Monitoring</li></ul>                                                                   |
+| Phase   | Objective                                                                                            | Status      |
+| ------- | ---------------------------------------------------------------------------------------------------- | ----------- |
+| Phase 1 | <ul><li>Develop a Standard SDK implementation in Go</li><li>Enable Streaming Pipeline Logs</li></ul> | DONE        |
+| Phase 2 | <ul><li>Variables</li></ul>                                                                          | IN PROGRESS |
+| Phase 3 | <ul><li>CI/CD Directed acyclic graph(DAG)</li></ul>                                                  | TODO        |
+| Phase 4 | <ul><li>Secrets</li></ul>                                                                            | TODO        |
+| Phase 5 | <ul><li>Parallel and Concurrent Workflow Execution</li></ul>                                         | TODO        |
+| Phase 5 | <ul><li>Authorization and RBAC</li></ul>                                                             | TODO        |
+| Phase 6 | <ul><li>System Observability and Monitoring</li></ul>                                                | TODO        |

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/dgraph-io/badger/v4 v4.8.0
 	github.com/fatih/color v1.15.0
 	github.com/go-resty/resty/v2 v2.15.3
-	github.com/gofiber/fiber/v2 v2.52.11
+	github.com/gofiber/fiber/v2 v2.52.12
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
-	github.com/nats-io/nats-server/v2 v2.11.8
+	github.com/nats-io/nats-server/v2 v2.11.15
 	github.com/nats-io/nats.go v1.44.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1


### PR DESCRIPTION
## Description

- Update roadmap
- Publish March 2026 update
- Fix known security issues, Bump `nats-server` to `v2.11.15` and fiber to `v2.11.15`

---

## Related Issues / Milestones

N/A

---

## Type of Change

<!-- Select one by marking [x] -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Security fix
- [ ] CI/CD or deployment

---

## How Has This Been Tested?

<!-- 
Describe the tests you ran to verify your changes.
Include instructions for reproducing the tests.
-->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

---

## Screenshots / Logs (If Applicable)

<!-- 
Attach relevant screenshots, terminal output, or logs
-->


---

## Additional Notes

<!-- 
Add any extra information reviewers should know, or note any follow-up work.
-->
