### PR TITLE
feat: add BadgerDB resource insertion (#221)

### DIFF
--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -32,27 +32,36 @@ func (m *ResourceModel) key(name string, resourceType string) string {
 // Insert adds a new resource to the etcd store.
 // It returns an error if a resource with the same name and type already exists.
 func (m *ResourceModel) Insert(name string, resourceType string, resource []byte) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
+	key := []byte(m.key(name, resourceType))
 
-	key := m.key(name, resourceType)
-
-	// Check existence
-	getResp, err := m.Client.Get(ctx, key)
+	// check existence
+	err := m.DB.View(func(txn *badger.Txn) error {
+		_, err := txn.Get(key)
+		if err == nil {
+			return fmt.Errorf("resource with name %s and type %s already exists", name, resourceType)
+		}
+		if err != badger.ErrKeyNotFound {
+			return err
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}
-	if len(getResp.Kvs) > 0 {
-		return fmt.Errorf("resource with name %s and type %s already exists", name, resourceType)
-	}
 
-	_, err = m.Client.Put(ctx, key, string(resource))
+	// insert resource
+	err = m.DB.Update(func(txn *badger.Txn) error {
+		return txn.Set(key, resource)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to insert resource: %v", err)
 	}
 
-	_, err = m.Client.Put(ctx, key+"/1", string(resource))
-	return err
+	// insert versioned resource
+	versionedKey := []byte(m.key(name, resourceType) + "/1")
+	return m.DB.Update(func(txn *badger.Txn) error {
+		return txn.Set(versionedKey, resource)
+	})
 }
 
 // FindOne retrieves a single resource by its name and type.

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -32,6 +32,30 @@ func (m *ResourceModel) key(name string, resourceType string) string {
 // Insert adds a new resource to the etcd store.
 // It returns an error if a resource with the same name and type already exists.
 func (m *ResourceModel) Insert(name string, resourceType string, resource []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	key := m.key(name, resourceType)
+
+	// Check existence
+	getResp, err := m.Client.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+	if len(getResp.Kvs) > 0 {
+		return fmt.Errorf("resource with name %s and type %s already exists", name, resourceType)
+	}
+
+	_, err = m.Client.Put(ctx, key, string(resource))
+	if err != nil {
+		return fmt.Errorf("failed to insert resource: %v", err)
+	}
+
+	_, err = m.Client.Put(ctx, key+"/1", string(resource))
+	return err
+}
+
+func (m *ResourceModel) BadgerDBInsert(name string, resourceType string, resource []byte) error {
 	key := []byte(m.key(name, resourceType))
 
 	// check existence

--- a/internal/models/resource_test.go
+++ b/internal/models/resource_test.go
@@ -1,0 +1,49 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/open-ug/conveyor/internal/models"
+)
+
+func setupTestDB(t *testing.T) *badger.DB {
+	opts := badger.DefaultOptions("").WithInMemory(true)
+	db, err := badger.Open(opts)
+	if err != nil {
+		t.Fatalf("failed to open badger db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func Test_Resource_Insert(t *testing.T) {
+	db := setupTestDB(t)
+
+	resourcemodel := models.NewResourceModel(nil, db)
+
+	err := resourcemodel.Insert("test-resource", "test-type", []byte("test-data"))
+	if err != nil {
+		t.Fatalf("failed to insert resource: %v", err)
+	}
+
+	// Verify the resource was inserted
+	err = db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte("/resources/test-type/test-resource"))
+		if err != nil {
+			return err
+		}
+		val, err := item.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+		if string(val) != "test-data" {
+			t.Errorf("expected 'test-data', got '%s'", string(val))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to verify resource: %v", err)
+	}
+
+}

--- a/internal/models/resource_test.go
+++ b/internal/models/resource_test.go
@@ -22,28 +22,51 @@ func Test_Resource_Insert(t *testing.T) {
 
 	resourcemodel := models.NewResourceModel(nil, db)
 
-	err := resourcemodel.Insert("test-resource", "test-type", []byte("test-data"))
-	if err != nil {
-		t.Fatalf("failed to insert resource: %v", err)
-	}
+	t.Run("Insert Resource", func(t *testing.T) {
+		err := resourcemodel.Insert("test-resource", "test-type", []byte("test-data"))
+		if err != nil {
+			t.Fatalf("failed to insert resource: %v", err)
+		}
 
-	// Verify the resource was inserted
-	err = db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get([]byte("/resources/test-type/test-resource"))
+		// Verify the resource was inserted
+		err = db.View(func(txn *badger.Txn) error {
+			item, err := txn.Get([]byte("/resources/test-type/test-resource"))
+			if err != nil {
+				return err
+			}
+			val, err := item.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
+			if string(val) != "test-data" {
+				t.Errorf("expected 'test-data', got '%s'", string(val))
+			}
+			return nil
+		})
 		if err != nil {
-			return err
+			t.Fatalf("failed to verify resource: %v", err)
 		}
-		val, err := item.ValueCopy(nil)
-		if err != nil {
-			return err
-		}
-		if string(val) != "test-data" {
-			t.Errorf("expected 'test-data', got '%s'", string(val))
-		}
-		return nil
 	})
-	if err != nil {
-		t.Fatalf("failed to verify resource: %v", err)
-	}
+
+	// verify versioned resource was inserted
+	t.Run("Verify Versioned Resource", func(t *testing.T) {
+		err := db.View(func(txn *badger.Txn) error {
+			item, err := txn.Get([]byte("/resources/test-type/test-resource/1"))
+			if err != nil {
+				return err
+			}
+			val, err := item.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
+			if string(val) != "test-data" {
+				t.Errorf("expected 'test-data', got '%s'", string(val))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("failed to verify versioned resource: %v", err)
+		}
+	})
 
 }

--- a/internal/models/resource_test.go
+++ b/internal/models/resource_test.go
@@ -23,7 +23,7 @@ func Test_Resource_Insert(t *testing.T) {
 	resourcemodel := models.NewResourceModel(nil, db)
 
 	t.Run("Insert Resource", func(t *testing.T) {
-		err := resourcemodel.Insert("test-resource", "test-type", []byte("test-data"))
+		err := resourcemodel.BadgerDBInsert("test-resource", "test-type", []byte("test-data"))
 		if err != nil {
 			t.Fatalf("failed to insert resource: %v", err)
 		}


### PR DESCRIPTION
## Description

This PR re implements resource insertion from using `etcd` as the key-value datastore to BadgerDB

---

## Related Issues / Milestones

Closes #211 

---

## Type of Change

<!-- Select one by marking [x] -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Security fix
- [ ] CI/CD or deployment

---

## How Has This Been Tested?

<!-- 
Describe the tests you ran to verify your changes.
Include instructions for reproducing the tests.
-->

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

---

## Screenshots / Logs (If Applicable)

<!-- 
Attach relevant screenshots, terminal output, or logs
-->


---

## Additional Notes


