### PR TITLE
Remove unnecessary debug print statements

### DIFF
--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/gofiber/fiber/v2"
@@ -64,7 +63,6 @@ func (h *MessageHandler) PublishMessage(c *fiber.Ctx) error {
 			"error": err.Error(),
 		})
 	}
-	fmt.Println("Saved to database")
 	jsonMsg, merr := json.Marshal(message)
 	if merr != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{

--- a/internal/handlers/resource_definitions.go
+++ b/internal/handlers/resource_definitions.go
@@ -188,7 +188,6 @@ func (h *ResourceDefinitionHandler) UpdateResourceDefinition(c *fiber.Ctx) error
 // @Failure 500 {object} map[string]interface{} "Internal server error"
 // @Router /resource-definitions/apply [post]
 func (h *ResourceDefinitionHandler) CreateOrUpdateResourceDefinition(c *fiber.Ctx) error {
-	fmt.Println("CreateOrUpdateResourceDefinition called")
 	var resourceDefinition types.ResourceDefinition
 	if err := c.BodyParser(&resourceDefinition); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -211,7 +210,6 @@ func (h *ResourceDefinitionHandler) CreateOrUpdateResourceDefinition(c *fiber.Ct
 
 	// Check if the resource definition already exists
 	existingDef, _ := h.ResourceDefinitionModel.FindOne(resourceName)
-	fmt.Println("resource exists")
 
 	if existingDef != nil {
 		// If it exists, update it

--- a/internal/handlers/resource_definitions_test.go
+++ b/internal/handlers/resource_definitions_test.go
@@ -3,7 +3,6 @@ package handlers_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -80,8 +79,6 @@ func Test_ResourceDefinition_CRUD(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		respBody, _ := io.ReadAll(resp.Body)
-		fmt.Println(string(respBody))
 		assert.Equal(t, http.StatusCreated, resp.StatusCode, "expected 201 Created on create")
 
 	})

--- a/internal/streaming/driver_logs.go
+++ b/internal/streaming/driver_logs.go
@@ -59,8 +59,6 @@ func (s *DriverLogsStreamer) StreamDriverLogsByRunID(c *fiber.Ctx) error {
 			// send dummy data
 			w.Flush()
 
-			// Send existing logs first (replay)
-			fmt.Println(logs)
 			for _, logEntry := range logs {
 				jsonData, err := json.Marshal(logEntry)
 				if err != nil {


### PR DESCRIPTION
# Summary
Removed unnecessary debug `fmt.Println` statements that were printing vague messages to stdout during runtime.

# Changes
- Removed debug print from message publishing flow
- Removed debug prints from resource definition creation/update flow
- Removed raw logs print from driver log streaming
- Removed debug response-body print from test code

# Testing
- Ran `go fmt ./...`
- Ran `go test ./...`
- Relevant packages pass
- Full test suite has unrelated Windows file permission failures in `internal/config/initialize`, because the tests expect Unix file modes