### PR TITLE
fx: update Docker Go base images

### DIFF
--- a/packaging/docker/Dockerfile.alpine
+++ b/packaging/docker/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # BUILD STAGE
-FROM golang:1.24.0 AS build
+FROM golang:1.25.0 AS build
 
 WORKDIR /go/src/conveyor
 

--- a/packaging/docker/Dockerfile.ubuntu
+++ b/packaging/docker/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
 # Building the binary of the App
-FROM golang:1.24.0 AS build
+FROM golang:1.25.0 AS build
 
 WORKDIR /go/src/boilerplate
 


### PR DESCRIPTION
## Summary

Updates both Docker build stages from `golang:1.24.0` to `golang:1.25.0`, matching the `go 1.25.0` directive in `go.mod`. This keeps the Ubuntu and Alpine image builds on a base image that satisfies the module's declared Go version.

Closes #237

## Verification

- `git diff --check -- packaging/docker/Dockerfile.ubuntu packaging/docker/Dockerfile.alpine`
- inline check that both Dockerfile `golang:` tags match the `go.mod` Go version

I also attempted `APP_ENV=test go test ./...`; dependencies resolved, but the suite hit an existing embedded-etcd integration failure (`failed to create WAL`). A local Docker build reached the Go build stage with the updated base image but was cut short by the local command timeout while downloading/building dependencies.
