### PR TITLE
chore: enable publishing `delete`, and `update` events

### DIFF
--- a/internal/engine/driver_result.go
+++ b/internal/engine/driver_result.go
@@ -47,7 +47,10 @@ func PublishResourceEvent(
 	resource types.Resource,
 	js jetstream.JetStream) (string, error) {
 
+	// Generate a unique run ID for this event
 	run_id := uuid.New().String()
+
+	// If the resource is not part of a pipeline, publish it directly to the resource subject
 	if resource.Pipeline == "" {
 
 		mID, err := utils.GenerateRandomID()
@@ -61,7 +64,7 @@ func PublishResourceEvent(
 		driverMsg := types.DriverMessage{
 			ID:      mID,
 			Payload: string(resourceData),
-			Event:   "create",
+			Event:   event,
 			RunID:   run_id,
 		}
 

--- a/internal/handlers/resource.go
+++ b/internal/handlers/resource.go
@@ -213,10 +213,26 @@ func (h *ResourceHandler) DeleteResource(c *fiber.Ctx) error {
 		})
 	}
 
-	err := h.ResourceModel.Delete(resourceName, resourceType)
+	// first find the resource to check if it exists
+	resource, err := h.ResourceModel.FindOne(resourceName, resourceType)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": fmt.Sprintf("Failed to find resource: %v", err),
+		})
+	}
+
+	err = h.ResourceModel.Delete(resourceName, resourceType)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": fmt.Sprintf("Failed to delete resource: %v", err),
+		})
+	}
+
+	// Publish resource deletion event to NATS JetStream
+	_, err = engine.PublishResourceEvent("delete", resource, h.NatsContext.JetStream)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": fmt.Sprintf("Failed to publish resource event: %v", err),
 		})
 	}
 
@@ -281,6 +297,28 @@ func (h *ResourceHandler) UpdateResource(c *fiber.Ctx) error {
 		})
 	}
 
+	// check if pipeline exists
+	if resource.Pipeline != "" {
+		pipeline, err := h.PipelineModel.GetPipeline(resource.Pipeline)
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"error": fmt.Sprintf("Failed to get pipeline: %v", err),
+			})
+		}
+
+		if pipeline == nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": fmt.Sprintf("Pipeline %s not found", resource.Pipeline),
+			})
+		}
+
+		if pipeline.Resource != resource.Resource {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": fmt.Sprintf("Resource type %s does not match pipeline resource type %s", resource.Resource, pipeline.Resource),
+			})
+		}
+	}
+
 	resourceDefinition, err := h.ResourceDefinitionModel.FindOne(resourceType)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -326,6 +364,14 @@ func (h *ResourceHandler) UpdateResource(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": fmt.Sprintf("Failed to update resource: %v", err),
+		})
+	}
+
+	// Publish `update` event to NATS JetStream
+	_, err = engine.PublishResourceEvent("update", r, h.NatsContext.JetStream)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": fmt.Sprintf("Failed to publish resource event: %v", err),
 		})
 	}
 


### PR DESCRIPTION
## Description

Driver events where not being published on when a resource was updated or deleted, this PR adds that functionality by allowing the handlers to publish a `delete` and `update` event upon their respective actions.

## Related Issues / Milestones

N/A

## Type of Change

<!-- Select one by marking [x] -->

- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Security fix
- [ ] CI/CD or deployment

## How Has This Been Tested?

<!-- 
Describe the tests you ran to verify your changes.
Include instructions for reproducing the tests.
-->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Additional Notes / Screenshots / Logs (If Applicable)

N/A