### PR TITLE
Add GHCR image publish workflow and switch official image references

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,0 +1,83 @@
+name: GitHub Container Registry Image CI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [ubuntu, alpine]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/open-ug/conveyor
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Prepare variant tags
+        id: variants
+        run: |
+          raw='${{ steps.meta.outputs.tags }}'
+          tags=$(printf '%s' "$raw" | tr ',' '\n')
+
+          ubuntu_tags=""
+          alpine_tags=""
+
+          for t in $tags; do
+            if [ -z "$t" ]; then
+              continue
+            fi
+            t=$(echo "$t" | xargs)
+            ubuntu_tags="${ubuntu_tags}${t},"
+            alpine_tags="${alpine_tags}${t}-alpine,"
+          done
+
+          ubuntu_tags="${ubuntu_tags%,}"
+          alpine_tags="${alpine_tags%,}"
+
+          echo "ubuntu_tags=$ubuntu_tags" >> "$GITHUB_OUTPUT"
+          echo "alpine_tags=$alpine_tags" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packaging/docker/Dockerfile.${{ matrix.variant }}
+          push: true
+          tags: ${{ matrix.variant == 'ubuntu' && steps.variants.outputs.ubuntu_tags || steps.variants.outputs.alpine_tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.event.release.tag_name }}

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -17,7 +17,7 @@ import TabItem from '@theme/TabItem';
 <Tabs>
   <TabItem value="docker" label="Docker Image" default>
     ```sh
-    docker run -d --name conveyor-ci openug/conveyor:latest
+    docker run -d --name conveyor-ci ghcr.io/open-ug/conveyor:latest
     ```
   </TabItem>
   <TabItem value="script" label="Installation Script">

--- a/packaging/docker/compose/compose.yml
+++ b/packaging/docker/compose/compose.yml
@@ -1,7 +1,7 @@
 # Edit this file to configure your Docker Compose setup
 services:
   app:
-    image: openug/conveyor:latest
+    image: ghcr.io/open-ug/conveyor:latest
     container_name: app
     depends_on:
       - etcd

--- a/packaging/helm/templates/NOTES.txt
+++ b/packaging/helm/templates/NOTES.txt
@@ -1,7 +1,7 @@
 Hey, Thank you for installing Conveyor 
 
-This chart deploys the Conveyor server using the official Docker image:
-  openug/conveyor
+This chart deploys the Conveyor server using the official container image:
+  ghcr.io/open-ug/conveyor
 
 ---------------------------------------------------------------------
 ## Accessing Conveyor
@@ -26,7 +26,7 @@ Conveyor expects its configuration at:
   /etc/conveyor/conveyor.yml
 
 By default, the chart mounts the configuration already included inside
-the official Docker image (generated via `conveyor init`).
+the official container image (generated via `conveyor init`).
 
 ### Override the configuration
 To provide your own conveyor.yml:
@@ -73,7 +73,7 @@ Enable overrides in values.yaml:
       existingSecret: conveyor-certs
 
 If overrides are disabled, Conveyor uses certificates baked into the
-official Docker image.
+official container image.
 
 ---------------------------------------------------------------------
 ## Persistent Storage

--- a/packaging/helm/values.yaml
+++ b/packaging/helm/values.yaml
@@ -1,4 +1,3 @@
-
 # Default values for Conveyor Helm Chart
 namespace: ""
 nameOverride: ""
@@ -12,9 +11,9 @@ pvc:
 ingress:
   enabled: false
 
-# the docker image 
+# the container image
 image: 
-  repository: openug/conveyor 
+  repository: ghcr.io/open-ug/conveyor
   tag: latest
   pullPolicy: IfNotPresent 
 


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow that publishes release container images to `ghcr.io/open-ug/conveyor`
- update installation, Docker Compose, and Helm references to use the GHCR image as the official image
- keep the existing Docker Hub build workflow unchanged while introducing the GHCR publish path

## Testing

- reviewed the workflow and compare diff in GitHub
- verified the branch is mergeable and includes 5 commits across 5 changed files

Closes #243