### PR TITLE
fix: lowercase GITHUB_REPOSITORY for GHCR image name

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -19,12 +19,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set lowercase repository name
+        run: echo "IMAGE_REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/open-ug/conveyor
+            ghcr.io/${{ env.IMAGE_REPO }}
           tags: |
             type=schedule
             type=ref,event=branch


### PR DESCRIPTION

## Description
Added a new step before the Docker metadata step to export a lowercase 
version of `GITHUB_REPOSITORY` as `IMAGE_REPO` via `$GITHUB_ENV` using 
bash parameter expansion `${GITHUB_REPOSITORY,,}`. Updated the Docker 
metadata step to reference `ghcr.io/${{ env.IMAGE_REPO }}` instead of 
the hardcoded `ghcr.io/open-ug/conveyor`.


## Related Issues / Milestones
Fixes #247

## Type of Change

- [ x] Bug fix
- [ x] CI/CD or deployment

## How Has This Been Tested?
- [x ] Manual testing

Published a dummy test release (`v0.0.2-test`) on the forked repository to trigger 
the `GitHub Container Registry Image CI` workflow. The workflow completed 
successfully, confirming the lowercase image name resolves correctly.

workflow run : https://github.com/Rktech8/conveyor/actions/runs/28282686739

## Additional Notes / Screenshots / Logs (If Applicable)
Note: Other workflows fail on fork due to missing repository secrets 
(Docker Hub credentials, signing keys) — unrelated to this fix.

<img width="1913" height="821" alt="image" src="https://github.com/user-attachments/assets/c49e9405-e9cb-499d-9f8f-ed90510d555c" />
<img width="1912" height="817" alt="image" src="https://github.com/user-attachments/assets/27a9f255-8328-4492-8d7b-49f0e56d3926" />
