### PR TITLE
Fix: Node 20 deprecation

### DIFF
--- a/.github/workflows/release-debian.yml
+++ b/.github/workflows/release-debian.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24.0"
 
@@ -40,7 +43,7 @@ jobs:
           ls -la ${{ github.workspace }}/..
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             ../conveyor_${{ env.VERSION_NO_V }}-1_${{ matrix.goarch }}.deb


### PR DESCRIPTION
## Description
Updates the release CI workflow to fix a build failure caused by GitHub Actions deprecating the Node 20 runtime.
softprops/action-gh-release@v2 ships on Node 20 and was failing on the upload step. This PR bumps that action to v3, along with actions/checkout (v3 -> v5) and actions/setup-go (v5 -> v6), and adds permissions: contents: write

## Related Issues / Milestones
Fixes #249

## Type of Change

<!-- Select one by marking [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Security fix
- [x] CI/CD or deployment
